### PR TITLE
Fix memory leak in read_rgba_from_png.h

### DIFF
--- a/include/read_rgba_from_png.h
+++ b/include/read_rgba_from_png.h
@@ -23,6 +23,7 @@ inline bool read_rgba_from_png(
   // copy into vector
   rgba.reserve(height*width*4);
   std::copy(rgba_raw,rgba_raw+height*width*4,std::back_inserter(rgba) );
+  free(rgba_raw);
   return true;
 }
 


### PR DESCRIPTION
While running valgrind I noticed a small leak

```
==13907== Memcheck, a memory error detector
==13907== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==13907== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==13907== Command: ./raster
==13907== 
==13907== 
==13907== HEAP SUMMARY:
==13907==     in use at exit: 2,949,100 bytes in 5 blocks
==13907==   total heap usage: 76 allocs, 71 frees, 13,273,032 bytes allocated
==13907== 
==13907== 2,949,100 bytes in 5 blocks are definitely lost in loss record 1 of 1
==13907==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==13907==    by 0x111932: stbi__malloc(unsigned long) (in ~/Desktop/csc317/computer-graphics-raster-images/build/raster)
==13907==    by 0x11A955: stbi__create_png_image_raw(stbi__png*, unsigned char*, unsigned int, int, unsigned int, unsigned int, int, int) (in ~/Desktop/csc317/computer-graphics-raster-images/build/raster)
==13907==    by 0x11BB5A: stbi__create_png_image(stbi__png*, unsigned char*, unsigned int, int, int, int, int) (in ~/Desktop/csc317/computer-graphics-raster-images/build/raster)
==13907==    by 0x11CF7E: stbi__parse_png_file(stbi__png*, int, int) (in ~/Desktop/csc317/computer-graphics-raster-images/build/raster)
==13907==    by 0x11D1CF: stbi__do_png(stbi__png*, int*, int*, int*, int) (in ~/Desktop/csc317/computer-graphics-raster-images/build/raster)
==13907==    by 0x11D342: stbi__png_load(stbi__context*, int*, int*, int*, int) (in ~/Desktop/csc317/computer-graphics-raster-images/build/raster)
==13907==    by 0x1119F5: stbi__load_main(stbi__context*, int*, int*, int*, int) (in ~/Desktop/csc317/computer-graphics-raster-images/build/raster)
==13907==    by 0x111BFC: stbi__load_flip(stbi__context*, int*, int*, int*, int) (in ~/Desktop/csc317/computer-graphics-raster-images/build/raster)
==13907==    by 0x11200A: stbi_load_from_file (in ~/Desktop/csc317/computer-graphics-raster-images/build/raster)
==13907==    by 0x111F6D: stbi_load (in ~/Desktop/csc317/computer-graphics-raster-images/build/raster)
==13907==    by 0x123CF3: read_rgba_from_png(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<unsigned char, std::allocator<unsigned char> >&, int&, int&) (in ~/Desktop/csc317/computer-graphics-raster-images/build/raster)
==13907== 
==13907== LEAK SUMMARY:
==13907==    definitely lost: 2,949,100 bytes in 5 blocks
==13907==    indirectly lost: 0 bytes in 0 blocks
==13907==      possibly lost: 0 bytes in 0 blocks
==13907==    still reachable: 0 bytes in 0 blocks
==13907==         suppressed: 0 bytes in 0 blocks
==13907== 
==13907== For lists of detected and suppressed errors, rerun with: -s
==13907== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

With this fix:

```
==22460== Memcheck, a memory error detector
==22460== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==22460== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==22460== Command: ./raster
==22460== 
==22460== 
==22460== HEAP SUMMARY:
==22460==     in use at exit: 0 bytes in 0 blocks
==22460==   total heap usage: 76 allocs, 76 frees, 13,273,032 bytes allocated
==22460== 
==22460== All heap blocks were freed -- no leaks are possible
==22460== 
==22460== For lists of detected and suppressed errors, rerun with: -s
==22460== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```